### PR TITLE
Fix assignment submission not emitting statement

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -63,7 +63,7 @@ class store extends php_obj implements log_writer {
      * Should the event be ignored (not logged)? Overrides helper_writer.
      * @param event_base $event
      * @return bool
-     * 
+     *
      */
     protected function is_event_ignored(event_base $event) {
         return false;
@@ -85,8 +85,16 @@ class store extends php_obj implements log_writer {
             // $this->error_log('');
             // $this->error_log_value('event', $event);
             $moodleevent = $moodlecontroller->createEvent($event);
+            if (is_null($moodleevent)) {
+                continue;
+            }
+
             // $this->error_log_value('moodleevent', $moodleevent);
             $translatorevent = $translatorcontroller->createEvent($moodleevent);
+            if (is_null($translatorevent)) {
+                continue;
+            }
+
             // $this->error_log_value('translatorevent', $translatorevent);
             $xapievent = $xapicontroller->createEvent($translatorevent);
             // $this->error_log_value('xapievent', $xapievent);


### PR DESCRIPTION
Hi, I'm finding that when I submit an assignment in Moodle, a statement isn't being sent to the LRS. The attached patch should fix this.

I think what is happening is that the \mod_assign\event\assessable_submitted event is being passed to insert_event_entries() in a list containing other events that aren't currently handled (specifically \assignsubmission_file\event\assessable_uploaded). This is causing a null parameter to be passed to $translatorcontroller->createEvent() which isn't allowed by the function signature, so it's throwing an exception which bails out of insert_event_entries() before the assessable_submitted event can be handled.
