### PR TITLE
Send statements to LRS in batches

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -105,8 +105,23 @@ class store extends php_obj implements log_writer {
         $this->error_log_value('moodleevent', $moodleevents);
         $translatorevents = $translatorcontroller->createEvents($moodleevents);
         $this->error_log_value('translatorevents', $translatorevents);
-        $xapievents = $xapicontroller->createEvents($translatorevents);
-        $this->error_log_value('xapievents', $xapievents);
+
+        if (empty($translatorevents)) {
+            return;
+        }
+
+        // Split statements into batches.
+        $eventbatches = array($translatorevents);
+        $maxbatchsize = get_config('logstore_xapi', 'maxbatchsize');
+
+        if (!empty($maxbatchsize) && $maxbatchsize < count($translatorevents)) {
+            $eventbatches = array_chunk($translatorevents, $maxbatchsize);
+        }
+
+        foreach ($eventbatches as $translatoreventsbatch) {
+            $xapievents = $xapicontroller->createEvents($translatoreventsbatch);
+            $this->error_log_value('xapievents', $xapievents);
+        }
 
     }
 

--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -95,22 +95,19 @@ class store extends php_obj implements log_writer {
         $translatorcontroller = new translator_controller();
 
         // Emits events to other APIs.
-        foreach ($events as $event) {
-            $event = (array) $event;
-            $this->error_log('');
-            $this->error_log_value('event', $event);
-            $moodleevent = $moodlecontroller->createEvent($event);
-            if (is_null($moodleevent)) {
-                continue;
-            }
-            $this->error_log_value('moodleevent', $moodleevent);
-            $translatorevents = $translatorcontroller->createEvents($moodleevent);
-            $this->error_log_value('translatorevents', $translatorevents);
-            foreach ($translatorevents as $index => $translatorevent) {
-                $xapievent = $xapicontroller->createEvent($translatorevent);
-                $this->error_log_value('xapievent', $xapievent);
-            }
+        foreach ($events as $index => $event) {
+            $events[$index] = (array) $event;
         }
+
+        $this->error_log('');
+        $this->error_log_value('events', $events);
+        $moodleevents = $moodlecontroller->createEvents($events);
+        $this->error_log_value('moodleevent', $moodleevents);
+        $translatorevents = $translatorcontroller->createEvents($moodleevents);
+        $this->error_log_value('translatorevents', $translatorevents);
+        $xapievents = $xapicontroller->createEvents($translatorevents);
+        $this->error_log_value('xapievents', $xapievents);
+
     }
 
     private function error_log_value($key, $value) {

--- a/lang/en/logstore_xapi.php
+++ b/lang/en/logstore_xapi.php
@@ -39,4 +39,8 @@ $string['backgroundmode'] = 'Send statements by scheduled task?';
 $string['backgroundmode_desc'] = 'This will force Moodle to send the statements to the LRS in the background,
         via a cron task. This will make the process less close to real time, but will help to prevent unpredictable
         Moodle performance linked to the performance of the LRS.';
+$string['maxbatchsize'] = 'Maximum batch size';
+$string['maxbatchsize_desc'] = 'Statements are sent to the LRS in batches. This setting controls the maximum number of
+        statements that will be sent in a single operation. Setting this to zero will cause all available statements to
+        be sent at once, although this is not recommended.';
 $string['taskemit'] = 'Emit records to LRS';

--- a/settings.php
+++ b/settings.php
@@ -41,4 +41,8 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configcheckbox('logstore_xapi/backgroundmode',
         get_string('backgroundmode', 'logstore_xapi'),
         get_string('backgroundmode_desc', 'logstore_xapi'), 0));
+
+    $settings->add(new admin_setting_configtext('logstore_xapi/maxbatchsize',
+        get_string('maxbatchsize', 'logstore_xapi'),
+        get_string('maxbatchsize_desc', 'logstore_xapi'), 30, PARAM_INT));
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,20 +29,22 @@ abstract class TestCase extends PhpUnitTestCase {
     public function testCreateEvent() {
         $input = $this->constructInput();
 
-        $moodle_event = $this->moodle_controller->createEvent($input);
-        $this->assertTrue($moodle_event != null, 'Check that the event exists in the expander controller.');
+        $moodle_events = $this->moodle_controller->createEvents([$input]);
+        $this->assertNotNull($moodle_events, 'Check that the event exists in the expander controller.');
 
-        $translator_event = $this->translator_controller->createEvent($moodle_event);
-        $this->assertTrue($translator_event != null, 'Check that the event exists in the translator controller.');
+        $translator_events = $this->translator_controller->createEvents($moodle_events);
+        $this->assertNotNull($translator_events, 'Check that the event exists in the translator controller.');
 
-        $xapi_event = $this->xapi_controller->createEvent($translator_event);
-        $this->assertTrue($xapi_event != null, 'Check that the event exists in the emitter controller.');
+        $xapi_events = $this->xapi_controller->createEvents($translator_events);
+        $this->assertNotNull($xapi_events, 'Check that the event exists in the emitter controller.');
 
-        $this->assertOutput($input, $xapi_event);
+        $this->assertOutput($input, $xapi_events);
     }
 
     protected function assertOutput($input, $output) {
-        $this->assertValidXapiStatement((new TinCanStatement($output))->asVersion('1.0.0'));
+        foreach ($output as $outputpart) {
+            $this->assertValidXapiStatement((new TinCanStatement($outputpart))->asVersion('1.0.0'));
+        }
     }
 
     protected function assertValidXapiStatement($output) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,13 +30,13 @@ abstract class TestCase extends PhpUnitTestCase {
         $input = $this->constructInput();
 
         $moodle_events = $this->moodle_controller->createEvents([$input]);
-        $this->assertNotNull($moodle_events, 'Check that the event exists in the expander controller.');
+        $this->assertNotNull($moodle_events, 'Check that the events exist in the expander controller.');
 
         $translator_events = $this->translator_controller->createEvents($moodle_events);
-        $this->assertNotNull($translator_events, 'Check that the event exists in the translator controller.');
+        $this->assertNotNull($translator_events, 'Check that the events exist in the translator controller.');
 
         $xapi_events = $this->xapi_controller->createEvents($translator_events);
-        $this->assertNotNull($xapi_events, 'Check that the event exists in the emitter controller.');
+        $this->assertNotNull($xapi_events, 'Check that the events exist in the emitter controller.');
 
         $this->assertOutput($input, $xapi_events);
     }


### PR DESCRIPTION
Hi, here is a patch implementing https://github.com/jlowe64/moodle-logstore_xapi/issues/43.

It depends on these changes to library code:
- https://github.com/LearningLocker/Moodle-Log-Expander/pull/25
- https://github.com/LearningLocker/Moodle-xAPI-Translator/pull/34
- https://github.com/LearningLocker/xAPI-Recipe-Emitter/pull/27
