### PR TITLE
It's no longer necessary to instantiate \MXTranslator\Events\Event and invoke its 'read' method just to get at the 'context' ext key

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -144,15 +144,12 @@ class store extends php_obj implements log_writer {
             $eventbatches = array_chunk($translatorevents, $maxbatchsize);
         }
 
-        $translatorevent = new Event();
-        $translatoreventreadreturn = @$translatorevent->read([]);
-
         $sentevents = [];
         foreach ($eventbatches as $translatoreventsbatch) {
             $xapievents = $xapicontroller->create_events($translatoreventsbatch);
             foreach (array_keys($xapievents) as $key) {
                 if (is_numeric($key)) {
-                    $k = $xapievents[$key]['context']['extensions'][$translatoreventreadreturn[0]['context_ext_key']]['id'];
+                    $k = $xapievents[$key]['context']['extensions'][Event::CONTEXT_EXT_KEY]['id'];
                     $sentevents[$k] = $xapievents['last_action_result'];
                 }
             }

--- a/lib/translator/src/Events/Event.php
+++ b/lib/translator/src/Events/Event.php
@@ -22,6 +22,12 @@ use \MXTranslator\Repository as Repository;
 use \stdClass as PhpObj;
 
 class Event extends PhpObj {
+
+    /**
+     * @var string
+     */
+    const CONTEXT_EXT_KEY = 'http://lrs.learninglocker.net/define/extensions/moodle_logstore_standard_log';
+
     protected static $xapitype = 'http://lrs.learninglocker.net/define/type/moodle/';
 
     /**
@@ -41,7 +47,7 @@ class Event extends PhpObj {
                 || $opts['course']->lang == '' ? "en" : $opts['course']->lang,
             'context_platform' => 'Moodle',
             'context_ext' => $opts['event'],
-            'context_ext_key' => 'http://lrs.learninglocker.net/define/extensions/moodle_logstore_standard_log',
+            'context_ext_key' => self::CONTEXT_EXT_KEY,
             'context_info' => $opts['info'],
             'time' => date('c', $opts['event']['timecreated']),
             'app_url' => $opts['app']->url,


### PR DESCRIPTION
Please see [this PR](https://github.com/LearningLocker/Moodle-xAPI-Translator/pull/66).
