### PR TITLE
Added Customizable Name Field from User Mapping

### DIFF
--- a/lang/en/logstore_xapi.php
+++ b/lang/en/logstore_xapi.php
@@ -50,3 +50,5 @@ $string['logguests'] = 'Log guest actions';
 $string['filters_help'] = 'Enable filters that INCLUDE some actions to be logged.';
 $string['mbox'] = 'Send user email';
 $string['mbox_desc'] = 'Statements identify the user with its email (mbox) or with its userid on the moodle platform (account). Checking this will send the email (mbox).';
+$string['account'] = 'Account';
+$string['account_desc'] = 'User field from the Moodle Datastore to send in the xAPI Actor Account field';

--- a/lib/emitter/src/Events/Event.php
+++ b/lib/emitter/src/Events/Event.php
@@ -62,7 +62,7 @@ abstract class Event extends PhpObj {
                 'name' => $opts[$key.'_name'],
                 'account' => [
                     'homePage' => $opts[$key.'_url'],
-                    'name' => $opts[$key.'_id'],
+                    'name' => $opts[$key.'_account'],
                 ],
             ];
         }

--- a/lib/translator/src/Events/Event.php
+++ b/lib/translator/src/Events/Event.php
@@ -31,12 +31,14 @@ class Event extends PhpObj {
      */
     public function read(array $opts) {
         $appname = $opts['app']->fullname ?: 'A Moodle site';
+		$subField = get_config('logstore_xapi', 'account') ?: 'id';
 
         return [[
             'user_id' => $opts['user']->id,
             'user_email' => $opts['user']->email,
             'user_url' => $opts['user']->url,
             'user_name' => $opts['user']->fullname,
+			'user_account' => $opts['user']->$subField,
             'context_lang' => is_null($opts['course']->lang)
                 || $opts['course']->lang == '' ? "en" : $opts['course']->lang,
             'context_platform' => 'Moodle',

--- a/settings.php
+++ b/settings.php
@@ -29,6 +29,9 @@ require_once(__DIR__ . '/vendor/autoload.php');
 use \MXTranslator\Controller as translator_controller;
 
 if ($hassiteconfig) {
+	// get list of user map settings for account association
+	$accountOpts = array_merge(['id'], \core_user::AUTHSYNCFIELDS);
+	
     // Endpoint.
     $settings->add(new admin_setting_configtext('logstore_xapi/endpoint',
         get_string('endpoint', 'logstore_xapi'), '',
@@ -40,6 +43,11 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configtext('logstore_xapi/password',
         get_string('password', 'logstore_xapi'), '', 'password', PARAM_TEXT));
 
+	// value to send under actor account field
+    $settings->add(new admin_setting_configselect('logstore_xapi/account',
+	    get_string('account', 'logstore_xapi'), 
+		get_string('account_desc', 'logstore_xapi'), 'id', $accountOpts));
+		
     // Switch background batch mode on.
     $settings->add(new admin_setting_configcheckbox('logstore_xapi/backgroundmode',
         get_string('backgroundmode', 'logstore_xapi'),


### PR DESCRIPTION
Added a UI configuration that allows users to replace the xAPI
Actor->Account->Name field with a mapping other than the user's Moodle
Id.