### PR TITLE
Update UserRegistered.php

### DIFF
--- a/lib/translator/src/Events/UserRegistered.php
+++ b/lib/translator/src/Events/UserRegistered.php
@@ -31,6 +31,7 @@ class UserRegistered extends Event {
             'user_id' => $opts['relateduser']->id,
             'user_url' => $opts['relateduser']->url,
             'user_name' => $opts['relateduser']->fullname,
+            'user_email' => $opts['relateduser']->email,
         ])];
     }
 }


### PR DESCRIPTION
Populate 'user_email'

**Description**
- Actor's email address is incorrect for UserRegistered event. It picks admin's email address not user's email address.
Current actor without the fix:
```
"actor": {
   "mbox": "mailto:moodle@example.com", // <-- Error
   "name": "John Smith",
   "objectType": "Agent"
}
```
**Related Issues**
- #135 - Similar bug for Course Completed Event 

**PR Type**
- Fix