### PR TITLE
fix: Fixes endpoint correction to close #184.

### DIFF
--- a/src/loader/lrs.php
+++ b/src/loader/lrs.php
@@ -18,9 +18,11 @@ namespace src\loader\lrs;
 defined('MOODLE_INTERNAL') || die();
 
 function correct_endpoint($endpoint) {
-    $nostatements = trim($endpoint, 'statements');
-    $noslash = trim($nostatements, '/');
-    return $noslash;
+    $endswithstatements = substr($endpoint, -11) === "/statements";
+    if ($endswithstatements) {
+        return substr($endpoint, 0, -11);
+    }
+    return rtrim($endpoint, '/');
 }
 
 function load_transormed_events_to_lrs(array $config, array $transformedevents) {


### PR DESCRIPTION
Fixes #184, thanks to @peterspicer-catalyst for finding the issue and proposing a solution 👍 upon reviewing their solution it seemed unnecessary to `rtrim` after removing `/statements` since it would already remove the trailing slash. 