### PR TITLE
Ensure correct language code format

### DIFF
--- a/src/transformer/utils/get_course_lang.php
+++ b/src/transformer/utils/get_course_lang.php
@@ -19,5 +19,10 @@ defined('MOODLE_INTERNAL') || die();
 
 function get_course_lang($course) {
     $haslang = is_null($course->lang) || $course->lang == '';
-    return $haslang ? 'en' : $course->lang;
+    
+    // Ensure en_US and the like get corrected to the standard en-US
+    $prepped_lang = mb_ereg_replace('_', '-', $haslang ? 'en' : $course->lang);
+    
+    // Ensure valid language format
+    return mb_ereg_match('^[a-zA-Z]{2}(-[a-zA-Z]{2})?$', $prepped_lang) ? $prepped_lang : 'en';
 }

--- a/src/transformer/utils/get_course_lang.php
+++ b/src/transformer/utils/get_course_lang.php
@@ -19,10 +19,10 @@ defined('MOODLE_INTERNAL') || die();
 
 function get_course_lang($course) {
     $haslang = is_null($course->lang) || $course->lang == '';
-    
-    // Ensure en_US and the like get corrected to the standard en-US
-    $prepped_lang = mb_ereg_replace('_', '-', $haslang ? 'en' : $course->lang);
-    
-    // Ensure valid language format
-    return mb_ereg_match('^[a-zA-Z]{2}(-[a-zA-Z]{2})?$', $prepped_lang) ? $prepped_lang : 'en';
+
+    // Ensure en_US and the like get corrected to the standard en-US.
+    $preppedlang = mb_ereg_replace('_', '-', $haslang ? 'en' : $course->lang);
+
+    // Ensure valid language format.
+    return mb_ereg_match('^[a-zA-Z]{2}(-[a-zA-Z]{2})?$', $preppedlang) ? $preppedlang : 'en';
 }


### PR DESCRIPTION
I was having an issue because we had es_CO in our DB instead of es-CO. Since this underscore notation is not uncommon, I thought you might want to validate the language code in this way.