### PR TITLE
fix: Limits the events processed in the cron to avoid overflows and timeouts.

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -112,7 +112,7 @@ class store extends php_obj implements log_writer {
                 'lrs_endpoint' => $this->get_config('endpoint', ''),
                 'lrs_username' => $this->get_config('username', ''),
                 'lrs_password' => $this->get_config('password', ''),
-                'lrs_max_batch_size' => get_max_batch_size(),
+                'lrs_max_batch_size' => $this->get_max_batch_size(),
             ],
         ];
         $loadedevents = \src\handler($handlerconfig, $events);

--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -77,6 +77,10 @@ class store extends php_obj implements log_writer {
         }
     }
 
+    public function get_max_batch_size() {
+        return $this->get_config('maxbatchsize', 100);
+    }
+
     public function process_events(array $events) {
         global $DB;
         global $CFG;
@@ -108,7 +112,7 @@ class store extends php_obj implements log_writer {
                 'lrs_endpoint' => $this->get_config('endpoint', ''),
                 'lrs_username' => $this->get_config('username', ''),
                 'lrs_password' => $this->get_config('password', ''),
-                'lrs_max_batch_size' => $this->get_config('maxbatchsize', 100),
+                'lrs_max_batch_size' => get_max_batch_size(),
             ],
         ];
         $loadedevents = \src\handler($handlerconfig, $events);

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -39,7 +39,12 @@ class emit_task extends \core\task\scheduled_task {
         global $DB;
         $manager = get_log_manager();
         $store = new store($manager);
-        $extractedevents = $DB->get_records('logstore_xapi_log', null, '', '*', 0, $store->get_max_batch_size());
+        $conditions = null;
+        $sort = '';
+        $fields = '*';
+        $limitfrom = 0; 
+        $limitnum = $store->get_max_batch_size();
+        $extractedevents = $DB->get_records('logstore_xapi_log', $conditions, $sort, $fields, $limitfrom, $limitnum);
         $loadedevents = $store->process_events($extractedevents);
         $loadedeventids = array_map(function ($transformedevent) {
             return $transformedevent['eventid'];

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -39,7 +39,7 @@ class emit_task extends \core\task\scheduled_task {
         global $DB;
         $manager = get_log_manager();
         $store = new store($manager);
-        $extractedevents = $DB->get_records('logstore_xapi_log');
+        $extractedevents = $DB->get_records('logstore_xapi_log', null, '', '*', 0, $store->get_max_batch_size());
         $loadedevents = $store->process_events($extractedevents);
         $loadedeventids = array_map(function ($transformedevent) {
             return $transformedevent['eventid'];

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -42,7 +42,7 @@ class emit_task extends \core\task\scheduled_task {
         $conditions = null;
         $sort = '';
         $fields = '*';
-        $limitfrom = 0; 
+        $limitfrom = 0;
         $limitnum = $store->get_max_batch_size();
         $extractedevents = $DB->get_records('logstore_xapi_log', $conditions, $sort, $fields, $limitfrom, $limitnum);
         $loadedevents = $store->process_events($extractedevents);


### PR DESCRIPTION
If the backlog in the logstore_xapi_log gets too long, then the call to get_records can either time out or runs out of memory.