### PR TITLE
fix: Improves attempt activity for #186.

### DIFF
--- a/src/transformer/events/mod_quiz/attempt_reviewed.php
+++ b/src/transformer/events/mod_quiz/attempt_reviewed.php
@@ -26,8 +26,7 @@ function attempt_reviewed(array $config, \stdClass $event) {
     $instructor = $repo->read_record_by_id('user', $event->userid);
     $course = $repo->read_record_by_id('course', $event->courseid);
     $attempt = $repo->read_record_by_id('quiz_attempts', $event->objectid);
-    // Quiz attempts don't have names, so this will resolve an issue with the batch send to the LRS later.
-    $attempt->name = 'attempt';
+    $coursemodule = $repo->read_record_by_id('course_modules', $event->contextinstanceid);
     $quiz = $repo->read_record_by_id('quiz', $attempt->quiz);
     $lang = utils\get_course_lang($course);
 
@@ -61,7 +60,7 @@ function attempt_reviewed(array $config, \stdClass $event) {
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/events/mod_quiz/attempt_started.php
+++ b/src/transformer/events/mod_quiz/attempt_started.php
@@ -25,8 +25,7 @@ function attempt_started(array $config, \stdClass $event) {
     $user = $repo->read_record_by_id('user', $event->relateduserid);
     $course = $repo->read_record_by_id('course', $event->courseid);
     $attempt = $repo->read_record_by_id('quiz_attempts', $event->objectid);
-    // Quiz attempts don't have names, so this will resolve an issue with the batch send to the LRS later.
-    $attempt->name = 'attempt';
+    $coursemodule = $repo->read_record_by_id('course_modules', $event->contextinstanceid);
     $quiz = $repo->read_record_by_id('quiz', $attempt->quiz);
     $lang = utils\get_course_lang($course);
 
@@ -48,7 +47,7 @@ function attempt_started(array $config, \stdClass $event) {
             ],
             'contextActivities' => [
                 'other' => [
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang)
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'grouping' => [
                     utils\get_activity\site($config),

--- a/src/transformer/events/mod_quiz/attempt_submitted/attempt_submitted.php
+++ b/src/transformer/events/mod_quiz/attempt_submitted/attempt_submitted.php
@@ -25,8 +25,7 @@ function attempt_submitted(array $config, \stdClass $event) {
     $user = $repo->read_record_by_id('user', $event->relateduserid);
     $course = $repo->read_record_by_id('course', $event->courseid);
     $attempt = $repo->read_record_by_id('quiz_attempts', $event->objectid);
-    // Quiz attempts don't have names, so this will resolve an issue with the batch send to the LRS later.
-    $attempt->name = 'attempt';
+    $coursemodule = $repo->read_record_by_id('course_modules', $event->contextinstanceid);
     $quiz = $repo->read_record_by_id('quiz', $attempt->quiz);
     $gradeitem = $repo->read_record('grade_items', [
         'itemmodule' => 'quiz',
@@ -53,7 +52,7 @@ function attempt_submitted(array $config, \stdClass $event) {
             ],
             'contextActivities' => [
                 'other' => [
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang)
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'grouping' => [
                     utils\get_activity\site($config),

--- a/src/transformer/events/mod_quiz/question_answered/essay.php
+++ b/src/transformer/events/mod_quiz/question_answered/essay.php
@@ -63,7 +63,7 @@ function essay(array $config, \stdClass $event, \stdClass $questionattempt, \std
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/events/mod_quiz/question_answered/multichoice.php
+++ b/src/transformer/events/mod_quiz/question_answered/multichoice.php
@@ -63,7 +63,7 @@ function multichoice(array $config, \stdClass $event, \stdClass $questionattempt
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/events/mod_quiz/question_answered/numerical.php
+++ b/src/transformer/events/mod_quiz/question_answered/numerical.php
@@ -64,7 +64,7 @@ function numerical(array $config, \stdClass $event, \stdClass $questionattempt, 
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/events/mod_quiz/question_answered/shortanswer.php
+++ b/src/transformer/events/mod_quiz/question_answered/shortanswer.php
@@ -63,7 +63,7 @@ function shortanswer(array $config, \stdClass $event, \stdClass $questionattempt
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/events/mod_quiz/question_answered/truefalse.php
+++ b/src/transformer/events/mod_quiz/question_answered/truefalse.php
@@ -64,7 +64,7 @@ function truefalse(array $config, \stdClass $event, \stdClass $questionattempt, 
                     utils\get_activity\site($config),
                     utils\get_activity\course($config, $course),
                     utils\get_activity\module($config, 'quiz', $quiz, $lang),
-                    utils\get_activity\module($config, 'attempt', $attempt, $lang),
+                    utils\get_activity\quiz_attempt($config, $attempt->id, $coursemodule->id),
                 ],
                 'category' => [
                     utils\get_activity\source($config),

--- a/src/transformer/utils/get_activity/quiz_attempt.php
+++ b/src/transformer/utils/get_activity/quiz_attempt.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace src\transformer\utils\get_activity;
+defined('MOODLE_INTERNAL') || die();
+
+use src\transformer\utils as utils;
+
+function quiz_attempt(array $config, $attemptid, $cmid) {
+    $lang = $config['source_lang'];
+
+    return [
+        'id' => $config['app_url'].'/mod/quiz/attempt.php?attempt='.$attemptid.'&cmid='.$cmid,
+        'definition' => [
+            'type' => 'http://adlnet.gov/expapi/activities/attempt',
+            'name' => [
+                $lang => 'Attempt',
+            ],
+        ],
+    ];
+}

--- a/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/data.json
+++ b/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/data.json
@@ -18,6 +18,14 @@
             "lang": "en"
         }
     ],
+    "course_modules": [
+        {
+            "id": 1,
+            "course": 1,
+            "module": 1,
+            "instance": 1
+        }
+    ],
     "quiz_attempts": [
         {
             "id": 1,

--- a/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/event.json
+++ b/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/event.json
@@ -5,6 +5,7 @@
     "timecreated": 1433946701,
     "objecttable": "attempt",
     "objectid": 1,
+    "contextinstanceid": 1,
     "eventname": "\\mod_quiz\\event\\attempt_reviewed",
     "relateduserid": 2
 }

--- a/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/statements.json
+++ b/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/statements.json
@@ -71,11 +71,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_started/existing_attempt_started/data.json
+++ b/tests/mod_quiz/attempt_started/existing_attempt_started/data.json
@@ -13,6 +13,14 @@
             "lang": "en"
         }
     ],
+    "course_modules": [
+        {
+            "id": 1,
+            "course": 1,
+            "module": 1,
+            "instance": 1
+        }
+    ],
     "quiz_attempts": [
         {
             "id": 1,

--- a/tests/mod_quiz/attempt_started/existing_attempt_started/event.json
+++ b/tests/mod_quiz/attempt_started/existing_attempt_started/event.json
@@ -5,5 +5,6 @@
     "timecreated": 1433946701,
     "objecttable": "attempt",
     "objectid": 1,
+    "contextinstanceid": 1,
     "eventname": "\\mod_quiz\\event\\attempt_started"
 }

--- a/tests/mod_quiz/attempt_started/existing_attempt_started/statements.json
+++ b/tests/mod_quiz/attempt_started/existing_attempt_started/statements.json
@@ -37,11 +37,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/essay/statements.json
+++ b/tests/mod_quiz/attempt_submitted/essay/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }
@@ -161,11 +161,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/multichoice/statements.json
+++ b/tests/mod_quiz/attempt_submitted/multichoice/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }
@@ -161,11 +161,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/no_questions/statements.json
+++ b/tests/mod_quiz/attempt_submitted/no_questions/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/numerical/statements.json
+++ b/tests/mod_quiz/attempt_submitted/numerical/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }
@@ -162,11 +162,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/shortanswer/statements.json
+++ b/tests/mod_quiz/attempt_submitted/shortanswer/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }
@@ -161,11 +161,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/truefalse/statements.json
+++ b/tests/mod_quiz/attempt_submitted/truefalse/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }
@@ -162,11 +162,11 @@
                         }
                     },
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }

--- a/tests/mod_quiz/attempt_submitted/unknown_qtype/statements.json
+++ b/tests/mod_quiz/attempt_submitted/unknown_qtype/statements.json
@@ -48,11 +48,11 @@
             "contextActivities": {
                 "other": [
                     {
-                        "id": "http:\/\/www.example.org\/mod\/attempt\/view.php?id=1",
+                        "id": "http:\/\/www.example.org\/mod\/quiz\/attempt.php?attempt=1&cmid=1",
                         "definition": {
-                            "type": "http:\/\/id.tincanapi.com\/activitytype\/lms\/module",
+                            "type": "http:\/\/adlnet.gov\/expapi\/activities\/attempt",
                             "name": {
-                                "en": "attempt"
+                                "en": "Attempt"
                             }
                         }
                     }


### PR DESCRIPTION
Changed it to this using `src/transformer/utils/get_activity/quiz_attempt.php`.
```json
{
  "id": "http://www.example.org/mod/quiz/attempt.php?attempt=1&cmid=1",
  "definition": {
    "type": "http://adlnet.gov/expapi/activities/attempt",
    "name": {
      "en": "Attempt"
    }
  }
}
```

Part of the solution to #186.