### PR TITLE
fix: Ensures statement duration isn't null.

### DIFF
--- a/src/transformer/utils/get_attempt_duration.php
+++ b/src/transformer/utils/get_attempt_duration.php
@@ -18,10 +18,11 @@ namespace src\transformer\utils;
 defined('MOODLE_INTERNAL') || die();
 
 function get_attempt_duration($attempt) {
-    if (isset($attempt->timefinish)) {
+    if (isset($attempt->timefinish) && isset($attempt->timestart)) {
         $seconds = $attempt->timefinish - $attempt->timestart;
-        return "PT".(string) $seconds."S";
-    } else {
-        return null;
+        if ($seconds > 0) {
+            return "PT".(string) $seconds."S";
+        }
     }
+    return null;
 }

--- a/src/transformer/utils/get_attempt_result.php
+++ b/src/transformer/utils/get_attempt_result.php
@@ -31,7 +31,7 @@ function get_attempt_result(array $config, $attempt, $gradeitem) {
     $success = $gradesum >= $passscore;
     $duration = get_attempt_duration($attempt);
 
-    return [
+    $result = [
         'score' => [
             'raw' => $rawscore,
             'min' => $minscore,
@@ -40,6 +40,11 @@ function get_attempt_result(array $config, $attempt, $gradeitem) {
         ],
         'completion' => $completed,
         'success' => $success,
-        'duration' => $duration,
     ];
+
+    if ($duration != null) {
+        $result['duration'] = $duration;
+    }
+
+    return $result;
 }


### PR DESCRIPTION
These changes prevents the plugin from crashing when timefinish=0. The `duration` key is not sent in such a case because it cannot be null if sent.