### PR TITLE
fix: Handles failed events for #223.

### DIFF
--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -47,15 +47,13 @@ class emit_task extends \core\task\scheduled_task {
         }, $loadedevents);
     }
 
-    private function extract_events() {
+    private function extract_events($limitnum) {
         global $DB;
         $manager = get_log_manager();
-        $store = new store($manager);
         $conditions = null;
         $sort = '';
         $fields = '*';
         $limitfrom = 0;
-        $limitnum = $store->get_max_batch_size();
         $extractedevents = $DB->get_records('logstore_xapi_log', $conditions, $sort, $fields, $limitfrom, $limitnum);
         return $extractedevents;
     }
@@ -65,8 +63,10 @@ class emit_task extends \core\task\scheduled_task {
      * Throw exceptions on errors (the job will be retried).
      */
     public function execute() {
+        $store = new store($manager);
+
         // Extracts, transforms, and loads events.
-        $extractedevents = $this->extract_events();
+        $extractedevents = $this->extract_events($store->get_max_batch_size());
         $loadedevents = $store->process_events($extractedevents);
 
         // Stores failed events.

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -49,7 +49,6 @@ class emit_task extends \core\task\scheduled_task {
 
     private function extract_events($limitnum) {
         global $DB;
-        $manager = get_log_manager();
         $conditions = null;
         $sort = '';
         $fields = '*';
@@ -63,6 +62,7 @@ class emit_task extends \core\task\scheduled_task {
      * Throw exceptions on errors (the job will be retried).
      */
     public function execute() {
+        $manager = get_log_manager();
         $store = new store($manager);
 
         // Extracts, transforms, and loads events.

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -37,7 +37,7 @@ class emit_task extends \core\task\scheduled_task {
         });
         $failedevents = array_map(function ($nonloadedevent) {
             return $nonloadedevent['event'];
-        });
+        }, $nonloadedevents);
         return $failedevents;
     }
 

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -41,7 +41,7 @@ class emit_task extends \core\task\scheduled_task {
         return $failedevents;
     }
 
-    private function get_event_ids($events) {
+    private function get_event_ids($loadedevents) {
         return array_map(function ($loadedevent) {
             return $loadedevent['event']->id;
         }, $loadedevents);

--- a/classes/task/emit_task.php
+++ b/classes/task/emit_task.php
@@ -61,7 +61,7 @@ class emit_task extends \core\task\scheduled_task {
         global $DB;
         $eventids = $this->get_event_ids($events);
         $DB->delete_records_list('logstore_xapi_log', 'id', $eventids);
-        mtrace("Events (".implode(', ', $loadedeventids).") have been successfully sent to LRS.");
+        mtrace("Events (".implode(', ', $eventids).") have been successfully sent to LRS.");
     }
 
     private function store_failed_events($events) {

--- a/db/install.xml
+++ b/db/install.xml
@@ -37,5 +37,39 @@
         <INDEX NAME="user-module" UNIQUE="false" FIELDS="userid, contextlevel, contextinstanceid, crud, edulevel, timecreated"/>
       </INDEXES>
     </TABLE>
+
+    <TABLE NAME="logstore_xapi_failed_log" COMMENT="xAPI holding table for failed events">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="eventname" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="component" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="action" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="target" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="objecttable" TYPE="char" LENGTH="50" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="objectid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="crud" TYPE="char" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="edulevel" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contextid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contextlevel" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contextinstanceid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="relateduserid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="anonymous" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Was this event anonymous at the time of triggering?"/>
+        <FIELD NAME="other" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="origin" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="cli, cron, ws, etc."/>
+        <FIELD NAME="ip" TYPE="char" LENGTH="45" NOTNULL="false" SEQUENCE="false" COMMENT="IP address"/>
+        <FIELD NAME="realuserid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="real user id when logged-in-as"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="timecreated" UNIQUE="false" FIELDS="timecreated"/>
+        <INDEX NAME="course-time" UNIQUE="false" FIELDS="courseid, anonymous, timecreated"/>
+        <INDEX NAME="user-module" UNIQUE="false" FIELDS="userid, contextlevel, contextinstanceid, crud, edulevel, timecreated"/>
+      </INDEXES>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -16,60 +16,66 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+function create_xapi_log_table($tablename) {
+    // Define table to be created.
+    $table = new xmldb_table($tablename);
+
+    // Adding fields to table.
+    $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+    $table->add_field('eventname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('component', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('action', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('target', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('objecttable', XMLDB_TYPE_CHAR, '50', null, null, null, null);
+    $table->add_field('objectid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('crud', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('edulevel', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('contextid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('contextlevel', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('contextinstanceid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('relateduserid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('anonymous', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0');
+    $table->add_field('other', XMLDB_TYPE_TEXT, null, null, null, null, null);
+    $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+    $table->add_field('origin', XMLDB_TYPE_CHAR, '10', null, null, null, null);
+    $table->add_field('ip', XMLDB_TYPE_CHAR, '45', null, null, null, null);
+    $table->add_field('realuserid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+
+    // Adding keys to table.
+    $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+    // Adding indexes to table.
+    $table->add_index('timecreated', XMLDB_INDEX_NOTUNIQUE, array('timecreated'));
+    $table->add_index('course-time', XMLDB_INDEX_NOTUNIQUE, array('courseid', 'anonymous', 'timecreated'));
+    $table->add_index('user-module', XMLDB_INDEX_NOTUNIQUE, array(
+        'userid',
+        'contextlevel',
+        'contextinstanceid',
+        'crud',
+        'edulevel',
+        'timecreated'
+    ));
+
+    // Conditionally launch create table.
+    if (!$dbman->table_exists($table)) {
+        $dbman->create_table($table);
+    }
+}
+
 function xmldb_logstore_xapi_upgrade($oldversion) {
     global $CFG, $DB;
 
     $dbman = $DB->get_manager();
 
+    if ($oldversion <= 2018082100) {
+        create_xapi_log_table('logstore_xapi_failed_log');
+        upgrade_plugin_savepoint(true, 2018082100, 'logstore', 'xapi');
+    }
+
     if ($oldversion < 2015081001) {
-
-        // Define table logstore_xapi_log to be created.
-        $table = new xmldb_table('logstore_xapi_log');
-
-        // Adding fields to table logstore_xapi_log.
-        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
-        $table->add_field('eventname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('component', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('action', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('target', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('objecttable', XMLDB_TYPE_CHAR, '50', null, null, null, null);
-        $table->add_field('objectid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('crud', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('edulevel', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('contextid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('contextlevel', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('contextinstanceid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('relateduserid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('anonymous', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('other', XMLDB_TYPE_TEXT, null, null, null, null, null);
-        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('origin', XMLDB_TYPE_CHAR, '10', null, null, null, null);
-        $table->add_field('ip', XMLDB_TYPE_CHAR, '45', null, null, null, null);
-        $table->add_field('realuserid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-
-        // Adding keys to table logstore_xapi_log.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-
-        // Adding indexes to table logstore_xapi_log.
-        $table->add_index('timecreated', XMLDB_INDEX_NOTUNIQUE, array('timecreated'));
-        $table->add_index('course-time', XMLDB_INDEX_NOTUNIQUE, array('courseid', 'anonymous', 'timecreated'));
-        $table->add_index('user-module', XMLDB_INDEX_NOTUNIQUE, array(
-            'userid',
-            'contextlevel',
-            'contextinstanceid',
-            'crud',
-            'edulevel',
-            'timecreated'
-        ));
-
-        // Conditionally launch create table for logstore_xapi_log.
-        if (!$dbman->table_exists($table)) {
-            $dbman->create_table($table);
-        }
-
-        // Xapi savepoint reached.
+        create_xapi_log_table('logstore_xapi_log');
         upgrade_plugin_savepoint(true, 2015081001, 'logstore', 'xapi');
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -69,14 +69,14 @@ function xmldb_logstore_xapi_upgrade($oldversion) {
 
     $dbman = $DB->get_manager();
 
-    if ($oldversion <= 2018082100) {
-        create_xapi_log_table('logstore_xapi_failed_log');
-        upgrade_plugin_savepoint(true, 2018082100, 'logstore', 'xapi');
-    }
-
     if ($oldversion < 2015081001) {
         create_xapi_log_table('logstore_xapi_log');
         upgrade_plugin_savepoint(true, 2015081001, 'logstore', 'xapi');
+    }
+
+    if ($oldversion <= 2018082100) {
+        create_xapi_log_table('logstore_xapi_failed_log');
+        upgrade_plugin_savepoint(true, 2018082100, 'logstore', 'xapi');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -16,7 +16,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-function create_xapi_log_table($tablename) {
+function create_xapi_log_table($dbman, $tablename) {
     // Define table to be created.
     $table = new xmldb_table($tablename);
 
@@ -65,17 +65,17 @@ function create_xapi_log_table($tablename) {
 }
 
 function xmldb_logstore_xapi_upgrade($oldversion) {
-    global $CFG, $DB;
+    global $DB;
 
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2015081001) {
-        create_xapi_log_table('logstore_xapi_log');
+        create_xapi_log_table($dbman, 'logstore_xapi_log');
         upgrade_plugin_savepoint(true, 2015081001, 'logstore', 'xapi');
     }
 
     if ($oldversion < 2018082100) {
-        create_xapi_log_table('logstore_xapi_failed_log');
+        create_xapi_log_table($dbman, 'logstore_xapi_failed_log');
         upgrade_plugin_savepoint(true, 2018082100, 'logstore', 'xapi');
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -74,7 +74,7 @@ function xmldb_logstore_xapi_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2015081001, 'logstore', 'xapi');
     }
 
-    if ($oldversion <= 2018082100) {
+    if ($oldversion < 2018082100) {
         create_xapi_log_table('logstore_xapi_failed_log');
         upgrade_plugin_savepoint(true, 2018082100, 'logstore', 'xapi');
     }

--- a/src/loader/log.php
+++ b/src/loader/log.php
@@ -18,11 +18,13 @@ namespace src\loader\log;
 
 defined('MOODLE_INTERNAL') || die();
 
+use src\loader\utils as utils;
+
 function load(array $config, array $transformedevents) {
     $statements = array_reduce($transformedevents, function ($result, $transformedevent) {
         $eventstatements = $transformedevent['statements'];
         return array_merge($result, $eventstatements);
     }, []);
     echo(json_encode($statements, JSON_PRETTY_PRINT)."\n");
-    return $transformedevents;
+    return utils\construct_loaded_events($transformedevents, true);
 }

--- a/src/loader/lrs.php
+++ b/src/loader/lrs.php
@@ -90,7 +90,7 @@ function load(array $config, array $events) {
         $loadedbatchevents = load_transormed_events_to_lrs($config, $batch);
         return array_merge($result, $loadedbatchevents);
     }, []);
-    
+
     // Flags events that weren't transformed successfully as events that didn't load.
     $failedtransformevents = utils\filter_transformed_events($events, false);
     $nonloadedevents = utils\construct_loaded_events($failedtransformevents, false);

--- a/src/loader/utils/construct_loaded_events.php
+++ b/src/loader/utils/construct_loaded_events.php
@@ -14,12 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace src\loader\none;
+namespace src\loader\utils;
 
 defined('MOODLE_INTERNAL') || die();
 
-use src\loader\utils as utils;
-
-function load(array $config, array $transformedevents) {
-    return utils\construct_loaded_events($transformedevents, true);
+function construct_loaded_events(array $transformedevents, $loaded) {
+    $loadedevents = array_map(function ($transformedevent) use ($loaded) {
+        return [
+            'event' => $transformedevent['event'],
+            'statements' => $transformedevent['statements'],
+            'transformed' => $transformedevent['transformed'],
+            'loaded' => $loaded,
+        ];
+    }, $transformedevents);
+    return $loadedevents;
 }

--- a/src/loader/utils/filter_transformed_events.php
+++ b/src/loader/utils/filter_transformed_events.php
@@ -14,12 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace src\loader\none;
+namespace src\loader\utils;
 
 defined('MOODLE_INTERNAL') || die();
 
-use src\loader\utils as utils;
-
-function load(array $config, array $transformedevents) {
-    return utils\construct_loaded_events($transformedevents, true);
+function filter_transformed_events(array $events, $transformed) {
+    $filteredevents = array_filter($events, function ($event) use ($transformed) {
+        return $event['transformed'] === $transformed;
+    });
+    return $filteredevents;
 }

--- a/src/transformer/handler.php
+++ b/src/transformer/handler.php
@@ -19,7 +19,7 @@ defined('MOODLE_INTERNAL') || die();
 
 function handler(array $config, array $events) {
     $eventfunctionmap = get_event_function_map();
-    $transformedevents = array_filter(array_map(function ($event) use ($config, $eventfunctionmap) {
+    $transformedevents = array_map(function ($event) use ($config, $eventfunctionmap) {
         $eventobj = (object) $event;
         try {
             $eventname = $eventobj->eventname;
@@ -33,17 +33,27 @@ function handler(array $config, array $events) {
             } else {
                 $eventstatements = [];
             }
+
+            // Returns successfully transformed event with its statements.
             $transformedevent = [
-                'eventid' => $eventobj->id,
+                'event' => $eventobj,
                 'statements' => $eventstatements,
+                'transformed' => true,
             ];
             return $transformedevent;
         } catch (\Exception $e) {
             $logerror = $config['log_error'];
-            $logerror("Caught exception for event id #" . $eventobj->id . ": " .  $e->getMessage());
+            $logerror("Failed transform for event id #" . $eventobj->id . ": " .  $e->getMessage());
             $logerror($e->getTraceAsString());
-            return null;
+
+            // Returns unsuccessfully transformed event without statements.
+            $transformedevent = [
+                'event' => $eventobj,
+                'statements' => [],
+                'transformed' => false,
+            ];
+            return $transformedevent;
         }
-    }, $events));
+    }, $events);
     return $transformedevents;
 }

--- a/version.php
+++ b/version.php
@@ -18,7 +18,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin = isset($plugin) && is_object($plugin) ? $plugin : new \stdClass();
 $plugin->component = 'logstore_xapi';
-$plugin->version = 2018073005;
+$plugin->version = 2018082100;
 $plugin->release = '';
 $plugin->requires = 2014111000;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR inserts failed events into the "mdl_logstore_xapi_failed_log" table as described in [my comment](https://github.com/xAPI-vle/moodle-logstore_xapi/issues/223#issuecomment-414616579) on issue #223. This allows failed events to be reported back to us and fixed, at which point the installer can update their plugin and move the events back into the "mdl_logstore_xapi_log" table for re-processing. Note that this currently only happens in background mode. A separate PR should be made at a later date to do this for non-background mode.

In future this could be further improved by validating statements in the transformer and setting the `transformed` property on events to `false` when statements are invalid. This would ensure that invalid statements aren't sent to the LRS, therefore these invalid statements can be added to the failed log for later re-processing and one invalid statement in a batch would not fail all of the events in the batch.

- @ht2 if you have a second can you code review this please?
- @VassAngels can you test this with your Moodle instance using the Cron script please? (I actually tested this today - Wed 22nd Aug 2018 - see check list below)

Initially let's test the following without changing any code.
- [x] Supported events get inserted to the LRS
- [x] Supported events are removed from the "mdl_logstore_xapi_log" table.
- [x] Supported events are not inserted into the "mdl_logstore_xapi_failed_log" table.
- [x] Unsupported events are removed from the "mdl_logstore_xapi_log" table.
- [x] Unsupported events are not inserted into the "mdl_logstore_xapi_failed_log" table.

Then let's insert errors into a transformer and trigger the event.
- [x] Events with errors in their transformer are removed from the "mdl_logstore_xapi_log" table.
- [x] Events with errors in their transformer are inserted into the "mdl_logstore_xapi_failed_log" table.

Then let's insert errors into the LRS loader and trigger some events.
- [x] Events are removed from the "mdl_logstore_xapi_log" table.
- [x] Events are inserted into the "mdl_logstore_xapi_failed_log" table.