### PR TITLE
fix: Fixes LRS usage with proxy to close #238.

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -84,7 +84,11 @@ class store extends php_obj implements log_writer {
     private function get_proxy_endpoint() {
         global $CFG;
         if (!empty($CFG->proxyhost)) {
-            return $CFG->proxyhost.':'.$CFG->proxyport;
+            if (!empty($CFG->proxyport)) {
+                return $CFG->proxyhost.':'.$CFG->proxyport;
+            } else {
+                return $CFG->proxyhost;
+            }
         }
         return null;
     }

--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -81,6 +81,14 @@ class store extends php_obj implements log_writer {
         return $this->get_config('maxbatchsize', 100);
     }
 
+    private function get_proxy_endpoint() {
+        global $CFG;
+        if (!empty($CFG->proxyhost)) {
+            return $CFG->proxyhost.':'.$CFG->proxyport;
+        }
+        return null;
+    }
+
     public function process_events(array $events) {
         global $DB;
         global $CFG;
@@ -114,6 +122,7 @@ class store extends php_obj implements log_writer {
                 'lrs_username' => $this->get_config('username', ''),
                 'lrs_password' => $this->get_config('password', ''),
                 'lrs_max_batch_size' => $this->get_max_batch_size(),
+                'lrs_proxy_endpoint' => $this->get_proxy_endpoint(),
             ],
         ];
         $loadedevents = \src\handler($handlerconfig, $events);

--- a/src/loader/lrs.php
+++ b/src/loader/lrs.php
@@ -31,6 +31,7 @@ function send_http_statements(array $config, array $statements) {
     $endpoint = $config['lrs_endpoint'];
     $username = $config['lrs_username'];
     $password = $config['lrs_password'];
+    $proxyendpoint = $config['lrs_proxy_endpoint'];
 
     $url = correct_endpoint($endpoint).'/statements';
     $auth = base64_encode($username.':'.$password);
@@ -41,6 +42,9 @@ function send_http_statements(array $config, array $statements) {
     curl_setopt($request, CURLOPT_POSTFIELDS, $postdata);
     curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
+    if (isset($proxyendpoint)) {
+        curl_setopt($request, CURLOPT_PROXY, $proxyendpoint);
+    }
     curl_setopt($request, CURLOPT_HTTPHEADER, [
         'Authorization: Basic '.$auth,
         'X-Experience-API-Version: 1.0.0',

--- a/tests/xapi_test_case.php
+++ b/tests/xapi_test_case.php
@@ -54,6 +54,7 @@ abstract class xapi_test_case extends PhpUnitTestCase {
                 'lrs_username' => '',
                 'lrs_password' => '',
                 'lrs_max_batch_size' => 1,
+                'lrs_proxy_endpoint' => null,
             ],
         ];
         $loadedevents = \src\handler($handlerconfig, [$event]);


### PR DESCRIPTION
@peterspicer-catalyst thanks for reporting this #238, I'm unable to test this right now. Are you able to test this by following the instructions below?

1. Navigate to the root directory of your Moodle installation in your terminal.
1. Run the commands below in sequence to get this branch of the plugin.
    ```sh
    cd `admin/tool/log/store`
    rm -rf xapi
    git clone git@github.com:xAPI-vle/moodle-logstore_xapi.git xapi
    cd xapi
    php -r "readfile('https://getcomposer.org/installer');" | php; rm -rf vendor; php composer.phar install
    git checkout origin/fix-proxy
    ```
1. Test that statements are sent from Moodle **with** a proxy configuration.
1. Test that statements are sent from Moodle **without** a proxy configuration.
