### PR TITLE
feat: Adds id number in object extension for courses and activities to close #230.

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -102,6 +102,7 @@ class store extends php_obj implements log_writer {
                 'send_mbox' => $this->get_config('mbox', false),
                 'send_response_choices' => $this->get_config('sendresponsechoices', false),
                 'send_short_course_id' => $this->get_config('shortcourseid', false),
+                'send_course_and_module_idnumber' => $this->get_config('sendidnumber', false),
                 'send_username' => $this->get_config('send_username', false),
                 'plugin_url' => 'https://github.com/xAPI-vle/moodle-logstore_xapi',
                 'plugin_version' => $plugin->release,

--- a/lang/en/logstore_xapi.php
+++ b/lang/en/logstore_xapi.php
@@ -45,5 +45,7 @@ $string['send_username'] = 'Identify users by id';
 $string['send_username_desc'] = 'Statements will identify users with their username when this box is ticked, but only if identifying users by email is disabled.';
 $string['shortcourseid'] = 'Send short course name';
 $string['shortcourseid_desc'] = 'Statements will contain the shortname for a course as a short course id extension';
+$string['sendidnumber'] = 'Send course and activity ID number';
+$string['sendidnumber_desc'] = 'Statements will include the ID number (admin defined) for courses and activities in the object extensions';
 $string['send_response_choices'] = 'Send response choices';
 $string['send_response_choices_desc'] = 'Statements for multiple choice question answers will be sent to the LRS with the correct response and potential choices';

--- a/settings.php
+++ b/settings.php
@@ -47,6 +47,10 @@ if ($hassiteconfig) {
         get_string('shortcourseid', 'logstore_xapi'),
         get_string('shortcourseid_desc', 'logstore_xapi'), 0));
 
+    $settings->add(new admin_setting_configcheckbox('logstore_xapi/sendidnumber',
+        get_string('sendidnumber', 'logstore_xapi'),
+        get_string('sendidnumber_desc', 'logstore_xapi'), 0));
+
     $settings->add(new admin_setting_configcheckbox('logstore_xapi/send_username',
         get_string('send_username', 'logstore_xapi'),
         get_string('send_username_desc', 'logstore_xapi'), 0));

--- a/src/transformer/utils/get_activity/course.php
+++ b/src/transformer/utils/get_activity/course.php
@@ -22,30 +22,25 @@ use src\transformer\utils as utils;
 function course(array $config, \stdClass $course) {
     $coursename = $course->fullname ? $course->fullname : 'A Moodle course';
     $courselang = utils\get_course_lang($course);
-    $sendshortid = utils\is_enabled_config($config, 'send_short_course_id');
 
-    if ($sendshortid) {
-        return [
-            'id' => $config['app_url'].'/course/view.php?id='.$course->id,
-            'definition' => [
-                'type' => 'http://id.tincanapi.com/activitytype/lms/course',
-                'name' => [
-                    $courselang => $coursename,
-                ],
-                'extensions' => [
-                    'https://w3id.org/learning-analytics/learning-management-system/short-id' => $course->shortname
-                ]
-            ],
-        ];
+    $object = [
+                  'id' => $config['app_url'].'/course/view.php?id='.$course->id,
+                  'definition' => [
+                      'type' => 'http://id.tincanapi.com/activitytype/lms/course',
+                      'name' => [
+                          $courselang => $coursename,
+                      ],
+                  ],
+              ];
+
+    if (utils\is_enabled_config($config, 'send_short_course_id')) {
+        $object['definition']['extensions']['https://w3id.org/learning-analytics/learning-management-system/short-id'] = $course->shortname;
     }
 
-    return [
-        'id' => $config['app_url'].'/course/view.php?id='.$course->id,
-        'definition' => [
-            'type' => 'http://id.tincanapi.com/activitytype/lms/course',
-            'name' => [
-                $courselang => $coursename,
-            ],
-        ],
-    ];
+    if (utils\is_enabled_config($config, 'send_course_and_module_idnumber')) {
+        $courseidnumber = property_exists($course, 'idnumber') ? $course->idnumber : null;
+        $object['definition']['extensions']['https://w3id.org/learning-analytics/learning-management-system/external-id'] = $courseidnumber;
+    }
+
+    return $object;
 }

--- a/src/transformer/utils/get_activity/course_module.php
+++ b/src/transformer/utils/get_activity/course_module.php
@@ -29,7 +29,7 @@ function course_module(array $config, $course, $cmid, $xapitype) {
     $courselang = utils\get_course_lang($course);
     $instancename = property_exists($instance, 'name') ? $instance->name : $module->name;
 
-    return [
+    $object = [
         'id' => $coursemoduleurl,
         'definition' => [
             'type' => $xapitype,
@@ -38,4 +38,11 @@ function course_module(array $config, $course, $cmid, $xapitype) {
             ],
         ],
     ];
+
+    if (utils\is_enabled_config($config, 'send_course_and_module_idnumber')) {
+        $moduleidnumber = property_exists($coursemodule, 'idnumber') ? $coursemodule->idnumber : null;
+        $object['definition']['extensions']['https://w3id.org/learning-analytics/learning-management-system/external-id'] = $moduleidnumber;
+    }
+
+    return $object;
 }

--- a/tests/mod_quiz/attempt_submitted/multichoice_withchoices/test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoice_withchoices/test.php
@@ -32,6 +32,7 @@ class test extends \tests\xapi_test_case {
             'send_mbox' => false,
             'send_response_choices' => true,
             'send_short_course_id' => false,
+            'send_course_and_module_idnumber' => false,
             'send_username' => false,
             'plugin_url' => 'https://github.com/xAPI-vle/moodle-logstore_xapi',
             'plugin_version' => '0.0.0-development',

--- a/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/test.php
@@ -32,6 +32,7 @@ class test extends \tests\xapi_test_case {
             'send_mbox' => false,
             'send_response_choices' => true,
             'send_short_course_id' => false,
+            'send_course_and_module_idnumber' => false,
             'send_username' => false,
             'plugin_url' => 'https://github.com/xAPI-vle/moodle-logstore_xapi',
             'plugin_version' => '0.0.0-development',

--- a/tests/xapi_test_case.php
+++ b/tests/xapi_test_case.php
@@ -77,6 +77,7 @@ abstract class xapi_test_case extends PhpUnitTestCase {
             'send_mbox' => false,
             'send_response_choices' => false,
             'send_short_course_id' => false,
+            'send_course_and_module_idnumber' => false,
             'send_username' => false,
             'plugin_url' => 'https://github.com/xAPI-vle/moodle-logstore_xapi',
             'plugin_version' => '0.0.0-development',


### PR DESCRIPTION
**Description**
Adds id number in object extension for courses and activities under the extension `https://w3id.org/learning-analytics/learning-management-system/external-id`.

There is a config option (disabled by default) for this extension to keep consistency with the shortid extension.

**Related Issues**
Related issue #230

**PR Type**
Enhancement
