### PR TITLE
fix sco_launched transformation

### DIFF
--- a/src/transformer/events/mod_scorm/sco_launched.php
+++ b/src/transformer/events/mod_scorm/sco_launched.php
@@ -21,12 +21,10 @@ defined('MOODLE_INTERNAL') || die();
 use src\transformer\utils as utils;
 
 function sco_launched(array $config, \stdClass $event) {
-    global $DB;
-
     $repo = $config['repo'];
     $user = $repo->read_record_by_id('user', $event->userid);
     $course = $repo->read_record_by_id('course', $event->courseid);
-    $scormscoes = $DB->get_record('scorm_scoes', array('id' => $event->objectid), 'scorm');
+    $scormscoes = $repo->read_record_by_id('scorm_scoes', $event->objectid);
     $scorm = $repo->read_record_by_id('scorm', $scormscoes->scorm);
     $lang = utils\get_course_lang($course);
 

--- a/src/transformer/events/mod_scorm/sco_launched.php
+++ b/src/transformer/events/mod_scorm/sco_launched.php
@@ -21,10 +21,14 @@ defined('MOODLE_INTERNAL') || die();
 use src\transformer\utils as utils;
 
 function sco_launched(array $config, \stdClass $event) {
+    global $DB;
+
     $repo = $config['repo'];
     $user = $repo->read_record_by_id('user', $event->userid);
     $course = $repo->read_record_by_id('course', $event->courseid);
-    $scorm = $repo->read_record_by_id('scorm', $event->objectid);
+    $scormscoes = $DB->get_record('scorm_scoes', array('id' => $event->objectid), 'scorm');
+    $scorm = $repo->read_record_by_id('scorm', $scormscoes->scorm);
+    //$scorm = $repo->read_record_by_id('scorm', $event->objectid);
     $lang = utils\get_course_lang($course);
 
     return [[

--- a/src/transformer/events/mod_scorm/sco_launched.php
+++ b/src/transformer/events/mod_scorm/sco_launched.php
@@ -28,7 +28,6 @@ function sco_launched(array $config, \stdClass $event) {
     $course = $repo->read_record_by_id('course', $event->courseid);
     $scormscoes = $DB->get_record('scorm_scoes', array('id' => $event->objectid), 'scorm');
     $scorm = $repo->read_record_by_id('scorm', $scormscoes->scorm);
-    //$scorm = $repo->read_record_by_id('scorm', $event->objectid);
     $lang = utils\get_course_lang($course);
 
     return [[


### PR DESCRIPTION
**Description**
- The sco_launched SCORM message would fail transformation because the objectid referred to the scoid not the row in the scorm table. This fixes the issue.

**Related Issues**
- #344

**PR Type**
- Fix
