### PR TITLE
LMS 1689 replay failed statements

### DIFF
--- a/classes/log/process.php
+++ b/classes/log/process.php
@@ -1,0 +1,249 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Process events.
+ *
+ * @package     logstore_xapi
+ * @subpackage  log
+ * @author      László Záborski <zaborski.laszlo@gmail.com> (http://www.zabo.hu)
+ * @copyright   2020 Learning Pool Ltd (http://learningpool.com)
+ */
+
+namespace logstore_xapi\log;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class for processing events from a given events id list.
+ *
+ *
+ *
+ * @package     logstore_xapi
+ * @subpackage  log
+ * @author      László Záborski <zaborski.laszlo@gmail.com> (http://www.zabo.hu)
+ * @copyright   2020 Learning Pool Ltd (http://learningpool.com)
+ */
+class process {
+
+    /**
+     * logstore database names.
+     */
+    const LOGSTORE_NEW = "logstore_xapi_log";
+    const LOGSTORE_FAILED = "logstore_xapi_failed_log";
+
+    /**
+     * List of event IDs.
+     *
+     * @var array event ids[]
+     */
+    protected $eventids = array();
+
+    /**
+     * The table where the process works
+     *
+     * @var string
+     */
+    protected $table = '';
+
+    /**
+     * A list containing the constructed sql fragment.
+     *
+     * @var string
+     */
+    protected $select = '1=1';
+
+    /**
+     * An array of parameters.
+     *
+     * @var string
+     */
+    protected $params = array();
+
+    /**
+     * logstore object
+     *
+     * @var \Class logstore
+     */
+    protected $store;
+
+    /**
+     * Process constructor.
+     *
+     * @param array $events event ids
+     * @param bool $failed this events are failed
+     * @throws \invalid_parameter_exception
+     */
+    public function __construct(array $events, $failed = true) {
+        global $DB;
+
+        $this->eventids = $events;
+        $this->table = self::LOGSTORE_FAILED;
+
+        if (!$failed) {
+            $this->table = self::LOGSTORE_NEW;
+        }
+
+        if (!empty($events)) {
+            list($insql, $this->params) = $DB->get_in_or_equal($this->eventids);
+            $this->select = 'id ' . $insql;
+        }
+
+        if (!$this->checkids()) {
+            throw new \invalid_parameter_exception("Unrecognised event's id given.");
+        }
+
+        $manager = get_log_manager();
+        $this->store = new store($manager);
+    }
+
+    /**
+     * Double check event ids are valid in the table.
+     *
+     * @return bool
+     */
+    protected function checkids() {
+        global $DB;
+
+        if (empty($this->eventids)) {
+            return true;
+        }
+
+        $counted = count($this->eventids);
+
+        $valid = $DB->count_records_select($this->table, $this->select, $this->params);
+
+        if ($valid === $counted) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return events limited by limitnum.
+     *
+     * @param int $limitnum if 0, means need all.
+     * @return array
+     */
+    protected function extract_events($limitnum = 0) {
+        global $DB;
+
+        $events = $DB->get_records_select($this->table, $this->select, $this->params, '', '*', 0, $limitnum);
+
+        return $events;
+    }
+
+    /**
+     * Get events IDs from the array of event objects.
+     * @param array $events Events
+     * @return array Events' IDs
+     */
+    protected function get_event_ids(array $events) {
+        return array_map(function ($event) {
+            return $event['event']->id;
+        }, $events);
+    }
+
+    /**
+     * Get failed events from loaded events array.
+     *
+     * @param array $events Loaded events
+     * @return array Failed events
+     */
+    public function get_failed_events(array $events) {
+        $nonloadedevents = array_filter($events, function ($loadedevent) {
+            return $loadedevent['loaded'] === false;
+        });
+        $failedevents = array_map(function ($nonloadedevent) {
+            return $nonloadedevent['event'];
+        }, $nonloadedevents);
+        return $failedevents;
+    }
+
+    /**
+     * Get successful events from loaded events array.
+     *
+     * @param array $events Loaded events
+     * @return array Successful events
+     */
+    public function get_successful_events(array $events) {
+        $loadedevents = array_filter($events, function ($loadedevent) {
+            return $loadedevent['loaded'] === true;
+        });
+        $successfulevents = array_map(function ($loadedevent) {
+            return $loadedevent['event'];
+        }, $loadedevents);
+        return $successfulevents;
+    }
+
+    /**
+     * Remove failed events and store them.
+     *
+     * @param array $events
+     */
+    public function store_failed_events(array $events) {
+        global $DB;
+
+        $eventids = $this->get_event_ids($events);
+
+        $DB->delete_records_list($this->table, 'id', $eventids);
+
+        $DB->insert_records(self::LOGSTORE_FAILED, $events);
+
+        mtrace(count($events) . " " . get_string('failed_events', 'logstore_xapi'));
+    }
+
+    /**
+     * Record successfil events.
+     *
+     * @param $events
+     */
+    public function record_successful_events($events) {
+        mtrace(count($events) . " " . get_string('successful_events', 'logstore_xapi'));
+    }
+
+    /**
+     * Remove processed events
+     *
+     * @param $events
+     * @return void
+     */
+    public function delete_processed_events($events) {
+        global $DB;
+
+        $eventids = $this->get_event_ids($events);
+
+        $DB->delete_records_list($this->table, 'id', $eventids);
+    }
+
+    /**
+     * Do the job.
+     * Throw exceptions on errors (the job will be retried).
+     */
+    public function execute() {
+        $events = $this->extract_events($this->store->get_max_batch_size());
+
+        if (empty($events)) {
+            return;
+        }
+
+        $loadedevents = $this->store->process_events($events);
+        $failedevents = $this->get_failed_events($loadedevents);
+        $successfulevents = $this->get_successful_events($loadedevents);
+        $this->store_failed_events($failedevents);
+        $this->record_successful_events($successfulevents);
+        $this->delete_processed_events($successfulevents);
+    }
+}

--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -19,6 +19,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../src/autoload.php');
 
+use core_plugin_manager;
 use \tool_log\log\writer as log_writer;
 use \tool_log\log\manager as log_manager;
 use \tool_log\helper\store as helper_store;
@@ -82,9 +83,23 @@ class store extends php_obj implements log_writer {
     }
 
     public function process_events(array $events) {
-        global $DB;
-        global $CFG;
-        require(__DIR__ . '/../../version.php');
+
+        $config = $this->get_handler_config();
+        $loadedevents = \src\handler($config, $events);
+
+        return $loadedevents;
+    }
+
+    /**
+     * Get handler configuration.
+     *
+     * @return array Handler configuration.
+     */
+    protected function get_handler_config() {
+        global $DB, $CFG;
+
+        $plugin = core_plugin_manager::instance()->get_plugin_info('logstore_xapi');
+
         $logerror = function ($message = '') {
             debugging($message, DEBUG_NORMAL);
         };
@@ -135,8 +150,7 @@ class store extends php_obj implements log_writer {
 
         $handlerconfig['transformer'] = array_merge($handlerconfig['transformer'], $source);
 
-        $loadedevents = \src\handler($handlerconfig, $events);
-        return $loadedevents;
+        return $handlerconfig;
     }
 
     /**


### PR DESCRIPTION
**Description**
- add a class to handle event processing named \logstore_xapi\log\process
This log processor require a parameter which is an array of log ids, second parameter is optional, input data came from failed or standard log table. 
- update store.php to use core function to get release data and to separate config data creating to a new function.

**PR Type**
- Enhancement
