### PR TITLE
LMS-2294 moodle-logstore_xapi: Skip insert from historical log if the…

### DIFF
--- a/classes/log/moveback.php
+++ b/classes/log/moveback.php
@@ -123,21 +123,29 @@ class moveback {
     protected function move_event($event) {
         global $DB;
 
-        if (!$this->historical) {
-            unset($event->errortype, $event->response);
-        }
-
-        $DB->insert_record(self::LOGSTORE_NEW, $event);
+        $skipinsert = false;
 
         if ($this->historical) {
             $params = array(
                 'logstorestandardlogid' => $event->id
             );
 
+            $event->logstorestandardlogid = $event->id;
+
+            if (!empty($DB->count_records(self::LOGSTORE_NEW, $params))) {
+                $skipinsert = true;
+            }
+
         } else {
+            unset($event->errortype, $event->response);
+
             $params = array(
                 'id' => $event->id
             );
+        }
+
+        if (!$skipinsert) {
+            $DB->insert_record(self::LOGSTORE_NEW, $event);
         }
 
         if (!empty($DB->count_records(XAPI_REPORT_SOURCE_FAILED, $params))) {


### PR DESCRIPTION
**Description**
Skip insert from historical log if the record already being in the xapi logstore

**Related Issues**
LMS-2230

**PR Type**
Enhancement
