### PR TITLE
Lms 2406 notification email content

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -14,12 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Renderer class for logstore_xapi
+ *
+ * @package    logstore_xapi
+ * @copyright  2020 Learning Pool Ltd <https://learningpool.com/>
+ * @author     Stephen O'Hara <stephen.ohara@learningpool.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace logstore_xapi\output;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin = isset($plugin) && is_object($plugin) ? $plugin : new \stdClass();
-$plugin->component = 'logstore_xapi';
-$plugin->version = 2020061000;
+use plugin_renderer_base;
 
-$plugin->release = '';
-$plugin->requires = 2018051700;
-$plugin->maturity = MATURITY_STABLE;
+class renderer extends plugin_renderer_base {
+
+}

--- a/classes/task/sendfailednotifications_task.php
+++ b/classes/task/sendfailednotifications_task.php
@@ -72,10 +72,16 @@ class sendfailednotifications_task extends \core\task\scheduled_task {
         return false;
     }
 
+    /**
+     * Get the counts of failures for each error type
+     *
+     * @return array
+     * @throws \dml_exception
+     */
     private function get_failed_counts() {
         global $DB;
 
-        $sql = 'SELECT errorname, COUNT(errorname)
+        $sql = 'SELECT eventname, COUNT(eventname) AS count
                   FROM {logstore_xapi_failed_log}
               GROUP BY errorname';
 

--- a/lang/en/logstore_xapi.php
+++ b/lang/en/logstore_xapi.php
@@ -103,6 +103,7 @@ $string['notificationtriggerlimitnotreached'] = "Notification trigger limit not 
 $string['user'] = 'User';
 $string['user_help'] = 'Searches the users fullname';
 $string['contextidnolongerexists'] = 'Context ID {$a} no longer exists';
+$string['count'] = 'Count';
 
 // Capabilities
 $string['xapi:viewerrorlog'] = 'View xAPI error log';

--- a/templates/failed_notification_email.mustache
+++ b/templates/failed_notification_email.mustache
@@ -23,13 +23,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <style>
-    table, th, td {
-      border: 1px solid black;
-      padding: 0.5em;
-    }
-  </style>
-  <title>{{#str}}datarequestemailsubject, logstore_xapi{{/str}}</title>
+  <title>{{#str}}failedsubject, logstore_xapi{{/str}}</title>
 </head>
 <body>
 <div>

--- a/templates/failed_notification_email.mustache
+++ b/templates/failed_notification_email.mustache
@@ -1,0 +1,62 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template logstore_xapi/failed_notification_email
+
+    Email template for the failed notifications.
+}}
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    table, th, td {
+      border: 1px solid black;
+      padding: 0.5em;
+    }
+  </style>
+  <title>{{#str}}datarequestemailsubject, logstore_xapi{{/str}}</title>
+</head>
+<body>
+<div>
+  <p>{{#str}}failedtosend, logstore_xapi{{/str}}</p>
+  <br/>
+  <p><a href="{{endpointurl}}">{{#str}}endpoint, logstore_xapi{{/str}}</a></p>
+  <p><a href="{{errorlogpageurl}}">{{#str}}errorlogpage, logstore_xapi{{/str}}</a></p>
+  <table>
+    <tr>
+      <th>
+        {{#str}}eventname, logstore_xapi{{/str}}
+      </th>
+      <th>
+        {{#str}}count, logstore_xapi{{/str}}
+      </th>
+    </tr>
+    {{# errors }}
+      <tr>
+        <td>
+          {{{ eventname }}}
+        </td>
+        <td>
+          {{{ count }}}
+        </td>
+      </tr>
+    {{/errors}}
+  </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
**Description**
- Changing the email notifications to list only counts of each error type. Using mustache templates for email content. Logging only 1 row per user per notification email and changes to the notification threshold.

**Related Issues**
- LMS-2406

**PR Type**
- Enhancement
