### PR TITLE
LMS-2580: fix XAPI_IMPORT_TYPE_LIVE (0) type check

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -282,7 +282,7 @@ function logstore_xapi_extract_events($limitnum = 0, $log = XAPI_REPORT_SOURCE_L
     global $DB;
 
     $conditions = null;
-    if ($type) {
+    if (!empty($type) || $type == XAPI_IMPORT_TYPE_LIVE) {
         $conditions = array("type" => $type);
     }
     $sort = '';

--- a/lib.php
+++ b/lib.php
@@ -278,7 +278,7 @@ function logstore_xapi_add_event_to_sent_log($event) {
  * @param int $type event type
  * @return array
  */
-function logstore_xapi_extract_events($limitnum = 0, $log, $type) {
+function logstore_xapi_extract_events($limitnum, $log, $type) {
     global $DB;
 
     $conditions = array("type" => $type);

--- a/lib.php
+++ b/lib.php
@@ -278,13 +278,10 @@ function logstore_xapi_add_event_to_sent_log($event) {
  * @param int $type event type
  * @return array
  */
-function logstore_xapi_extract_events($limitnum = 0, $log = XAPI_REPORT_SOURCE_LOG, $type = null) {
+function logstore_xapi_extract_events($limitnum = 0, $log, $type) {
     global $DB;
 
-    $conditions = null;
-    if (!empty($type) || $type == XAPI_IMPORT_TYPE_LIVE) {
-        $conditions = array("type" => $type);
-    }
+    $conditions = array("type" => $type);
     $sort = '';
     $fields = '*';
     $limitfrom = 0;


### PR DESCRIPTION
**Description**
- Check if XAPI_IMPORT_TYPE_LIVE (0) is being sent. Before this change if 0 was passed $conditions would not be set. In the original code before refactoring this method was used in the process() method with optional params. Since param 2 is optional, param 3 must also be optional.

**Related Issues**
- #2580

**PR Type**
- Fix.
