### PR TITLE
LMS-2657 - send username 

### DIFF
--- a/src/transformer/utils/get_user.php
+++ b/src/transformer/utils/get_user.php
@@ -29,7 +29,7 @@ function get_user(array $config, \stdClass $user) {
         ];
     }
 
-    if (array_key_exists('send_username', $config) && $config['send_username'] === true) {
+    if (array_key_exists('send_username', $config) && $config['send_username'] == true) {
         return [
             'name' => $fullname,
             'account' => [


### PR DESCRIPTION
**Description**
- resolves issue where username not being sent in `actor.account.name` when 'Identify users by id' is checked and 'Identify users by email' is not checked.

**Related Issues**
- #733

**PR Type**
- Fix
