### PR TITLE
LMS-2939 moodle-logstore_xapi: using formelements at dateto variable.

### DIFF
--- a/report.php
+++ b/report.php
@@ -177,7 +177,7 @@ if (isset($formelements)) {
 
     if (!empty($formelements->dateto)) {
         $where[] = 'x.timecreated <= :dateto';
-        $params['dateto'] = $fromform->dateto;
+        $params['dateto'] = $formelements->dateto;
     }
 }
 


### PR DESCRIPTION
**Description**
Using formelements at dateto.

**Related Issues**
LMS-2939

**PR Type**
Fix
