### PR TITLE
Lms 1960 investigate code changes

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -191,7 +191,7 @@ function xmldb_logstore_xapi_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        // Xapi savepoint reached.
+        // The xAPI savepoint reached.
         upgrade_plugin_savepoint(true, 2020032700, 'logstore', 'xapi');
     }
 
@@ -209,7 +209,7 @@ function xmldb_logstore_xapi_upgrade($oldversion) {
 
         create_xapi_sent_log_table($dbman, "logstore_xapi_sent_log");
 
-        // Xapi savepoint reached.
+        // The xAPI savepoint reached.
         upgrade_plugin_savepoint(true, 2020050600, 'logstore', 'xapi');
     }
 

--- a/lib.php
+++ b/lib.php
@@ -239,7 +239,7 @@ function logstore_xapi_get_info_string($row) {
                 // Unauthorised, could be an issue with xAPI credentials.
                 return get_string('autherror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_LRS:
-                // XAPI server error.
+                // xAPI server error.
                 return get_string('lrserror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_TRANSFORM:
                 // Transform error.

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@ define('XAPI_REPORT_ERRORTYPE_NETWORK', 101);
 define('XAPI_REPORT_ERRORTYPE_RECIPE', 400);
 define('XAPI_REPORT_ERRORTYPE_AUTH', 401);
 define('XAPI_REPORT_ERRORTYPE_LRS', 500);
-define('XAPI_REPORT_ERRORTYPE_TRANSFORM', 10000); // This high number has been set to avoid conflicting with other error codes
+define('XAPI_REPORT_ERRORTYPE_TRANSFORM', 10000); // This high number has been set to avoid conflicting with other error codes.
 
 // Resend values.
 define('XAPI_REPORT_RESEND_FALSE', 0);
@@ -116,18 +116,18 @@ function logstore_xapi_get_cohort_members($cohortids) {
  * @return array Returns an array of user objects from cohorts and additional email addresses.
  */
 function logstore_xapi_get_users_for_notifications() {
-    // get selected cohort users, will return a blank array if no cohorts are set.
+    // Get selected cohort users, will return a blank array if no cohorts are set.
     $cohorts = logstore_xapi_get_selected_cohorts();
     $users = logstore_xapi_get_cohort_members($cohorts);
 
-    // Get the manually set email addresses from the config
+    // Get the manually set email addresses from the config.
     $emailaddresses = get_config('logstore_xapi', 'send_additional_email_addresses');
     $emailaddresses = explode(",", $emailaddresses);
     foreach ($emailaddresses as $email) {
-        // Remove whitespace from email addresses
+        // Remove whitespace from email addresses.
         $email = preg_replace('/\s+/', '', $email);
         if (validate_email($email)) {
-            // If the email address is valid then add it to the list of users
+            // If the email address is valid then add it to the list of users.
             $user = new stdClass();
             $user->email = $email;
             $users[] = $user;
@@ -213,7 +213,7 @@ function logstore_xapi_get_event_names_array() {
  */
 function logstore_xapi_decode_response($response) {
     $decode = json_decode($response, true);
-    // Check JSON is valid
+    // Check JSON is valid.
     if (json_last_error() === JSON_ERROR_NONE) {
         return $decode;
     }
@@ -233,24 +233,24 @@ function logstore_xapi_get_info_string($row) {
             case XAPI_REPORT_ERRORTYPE_NETWORK:
                 return get_string('networkerror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_RECIPE:
-                // Recipe issue
+                // Recipe issue.
                 return get_string('recipeerror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_AUTH:
-                // Unauthorised, could be an issue with xAPI credentials
+                // Unauthorised, could be an issue with xAPI credentials.
                 return get_string('autherror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_LRS:
-                // xAPI server error
+                // XAPI server error.
                 return get_string('lrserror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_TRANSFORM:
-                // Transform error
+                // Transform error.
                 return get_string('failedtransformresponse', 'logstore_xapi', $row->eventname);
             default:
-                // Generic error catch all
+                // Generic error catch all.
                 return get_string('unknownerror', 'logstore_xapi', $row->errortype);
                 break;
         }
     }
-    return ''; // Return blank if no errortype captured
+    return ''; // Return blank if no errortype captured.
 }
 
 /**
@@ -310,7 +310,7 @@ function logstore_xapi_extract_events($limitnum, $log, $type) {
 /**
  * Get event ids.
  *
- * @param array $events raw events data
+ * @param array $loadedevents raw events data
  * @return array
  */
 function logstore_xapi_get_event_ids($loadedevents) {

--- a/lib.php
+++ b/lib.php
@@ -239,7 +239,7 @@ function logstore_xapi_get_info_string($row) {
                 // Unauthorised, could be an issue with xAPI credentials.
                 return get_string('autherror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_LRS:
-                // xAPI server error.
+                // The xAPI server error.
                 return get_string('lrserror', 'logstore_xapi');
             case XAPI_REPORT_ERRORTYPE_TRANSFORM:
                 // Transform error.

--- a/settings.php
+++ b/settings.php
@@ -99,8 +99,8 @@ if ($hassiteconfig) {
         $arrcohorts[$cohort->id] = $cohort->name;
     }
 
-    // If there are no cohorts then do not display this option
-    // especially when displaying the settings page for the first time after an upgrade
+    // If there are no cohorts then do not display this option,
+    // especially when displaying the settings page for the first time after an upgrade.
     if (count($arrcohorts) != 0) {
         $settings->add(new admin_setting_configmulticheckbox('logstore_xapi/cohorts',
             get_string('includecohorts', 'logstore_xapi'), '', '', $arrcohorts));

--- a/settings.php
+++ b/settings.php
@@ -128,7 +128,7 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configmulticheckbox('logstore_xapi/routes',
         get_string('routes', 'logstore_xapi'), '', $menuroutes, $menuroutes));
 
-    // xAPI Error Log page.
+    // The xAPI Error Log page.
     $errorreport = new admin_externalpage(
         'logstorexapierrorlog',
         get_string('logstorexapierrorlog', 'logstore_xapi'),
@@ -137,7 +137,7 @@ if ($hassiteconfig) {
     );
     $ADMIN->add('logging', $errorreport);
 
-    // xAPI Historic Log page.
+    // The xAPI Historic Log page.
     $historicreport = new admin_externalpage(
         'logstorexapihistoriclog',
         get_string('logstorexapihistoriclog', 'logstore_xapi'),

--- a/src/loader/utils/load_batch.php
+++ b/src/loader/utils/load_batch.php
@@ -38,8 +38,8 @@ function load_batch(array $config, array $transformedevents, callable $loader) {
         $errormessage = $e->getMessage();
         foreach ($transformedevents as $event) {
             if ($event["transformed"] == true) {
-                $event["event"]->errortype = $errorcode;
                 $event["event"]->response = $errormessage;
+                $event["event"]->errortype = $errorcode;
             }
         }
 

--- a/src/transformer/utils/get_verb.php
+++ b/src/transformer/utils/get_verb.php
@@ -50,7 +50,7 @@ function get_verb($verb, array $config, $lang) {
                 ]
             ];
 
-            // JISC specific verb id
+            // JISC specific verb id.
             if (utils\is_enabled_config($config, 'send_jisc_data')) {
                 $output['id'] = 'https://brindlewaye.com/xAPITerms/verbs/loggedin';
             }
@@ -64,7 +64,7 @@ function get_verb($verb, array $config, $lang) {
                 ],
             ];
 
-            // JISC specific verb id
+            // JISC specific verb id.
             if (utils\is_enabled_config($config, 'send_jisc_data')) {
                 $output['id'] = 'https://brindlewaye.com/xAPITerms/verbs/loggedout';
             }

--- a/tests/enchancement_jisc_skeleton.php
+++ b/tests/enchancement_jisc_skeleton.php
@@ -56,6 +56,9 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         'username' => XAPI_REPORT_USERNAME_DEFAULT,
     ];
 
+    /**
+     * This method is called before each test.
+     */
     protected function setUp() {
         global $CFG;
 

--- a/tests/enchancement_jisc_skeleton.php
+++ b/tests/enchancement_jisc_skeleton.php
@@ -40,7 +40,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
     /**
      * @var int Generated xapi-log events numbers
      */
-    protected $generatedxapylog = 1;
+    protected $generatedxapilog = 1;
 
     /**
      * @var array Form defaults.
@@ -73,7 +73,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         // From Moodle 3.9 an extra event has been added.
         if ($version >= 2020061500) {
             $this->generatedhistorylog = 12;
-            $this->generatedxapylog = 2;
+            $this->generatedxapilog = 2;
         }
     }
 
@@ -216,7 +216,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         $this->assertTrue($this->add_test_log_data($generator));
 
         $expectedcount->logstore_standard_log = $this->generatedhistorylog;
-        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
+        $expectedcount->logstore_xapi_log = $this->generatedxapilog;
         $this->assert_store_tables($expectedcount);
 
     }
@@ -236,7 +236,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         $this->assertTrue($this->add_test_log_data($generator));
 
         $expectedcount->logstore_standard_log = $this->generatedhistorylog;
-        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
+        $expectedcount->logstore_xapi_log = $this->generatedxapilog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
 
@@ -249,7 +249,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
 
         unset($expectedcount->logstore_standard_log);
         $expectedcount->logstore_xapi_log = 0;
-        $expectedcount->logstore_xapi_failed_log = $this->generatedxapylog;
+        $expectedcount->logstore_xapi_failed_log = $this->generatedxapilog;
         $this->assert_store_tables($expectedcount);
     }
 
@@ -272,7 +272,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         }
 
         unset($expectedcount->logstore_standard_log);
-        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapylog;
+        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapilog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
 
@@ -284,7 +284,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         ob_end_clean();
 
         $expectedcount->logstore_xapi_log = 0;
-        $expectedcount->logstore_xapi_failed_log = $this->multipletestnumber * $this->generatedxapylog;
+        $expectedcount->logstore_xapi_failed_log = $this->multipletestnumber * $this->generatedxapilog;
         $this->assert_store_tables($expectedcount);
     }
 }

--- a/tests/enchancement_jisc_skeleton.php
+++ b/tests/enchancement_jisc_skeleton.php
@@ -33,6 +33,16 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
     protected $multipletestnumber = 5;
 
     /**
+     * @var int Generated history-log events numbers
+     */
+    protected $generatedhistorylog = 11;
+
+    /**
+     * @var int Generated xapi-log events numbers
+     */
+    protected $generatedxapylog = 1;
+
+    /**
      * @var array Form defaults.
      */
     protected $formdefaults = [
@@ -45,6 +55,24 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         'response' => XAPI_REPORT_RESPONSE_DEFAULT,
         'username' => XAPI_REPORT_USERNAME_DEFAULT,
     ];
+
+    protected function setUp() {
+        global $CFG;
+
+        parent::setUp();
+
+        require($CFG->dirroot . '/version.php');
+
+        if (empty($version)) {
+            return;
+        }
+
+        // From Moodle 3.9 an extra event has been added.
+        if ($version >= 2020061500) {
+            $this->generatedhistorylog = 12;
+            $this->generatedxapylog = 2;
+        }
+    }
 
     /**
      * Investigate given counts.
@@ -184,8 +212,8 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         $generator = $this->getDataGenerator();
         $this->assertTrue($this->add_test_log_data($generator));
 
-        $expectedcount->logstore_standard_log = 11;
-        $expectedcount->logstore_xapi_log = 1;
+        $expectedcount->logstore_standard_log = $this->generatedhistorylog;
+        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
         $this->assert_store_tables($expectedcount);
 
     }
@@ -204,8 +232,8 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         $generator = $this->getDataGenerator();
         $this->assertTrue($this->add_test_log_data($generator));
 
-        $expectedcount->logstore_standard_log = 11;
-        $expectedcount->logstore_xapi_log = 1;
+        $expectedcount->logstore_standard_log = $this->generatedhistorylog;
+        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
 
@@ -218,7 +246,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
 
         unset($expectedcount->logstore_standard_log);
         $expectedcount->logstore_xapi_log = 0;
-        $expectedcount->logstore_xapi_failed_log = 1;
+        $expectedcount->logstore_xapi_failed_log = $this->generatedxapylog;
         $this->assert_store_tables($expectedcount);
     }
 
@@ -241,7 +269,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         }
 
         unset($expectedcount->logstore_standard_log);
-        $expectedcount->logstore_xapi_log = $this->multipletestnumber;
+        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapylog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
 
@@ -253,7 +281,7 @@ abstract class enchancement_jisc_skeleton extends advanced_testcase {
         ob_end_clean();
 
         $expectedcount->logstore_xapi_log = 0;
-        $expectedcount->logstore_xapi_failed_log = $this->multipletestnumber;
+        $expectedcount->logstore_xapi_failed_log = $this->multipletestnumber * $this->generatedxapylog;
         $this->assert_store_tables($expectedcount);
     }
 }

--- a/tests/failed_report_test.php
+++ b/tests/failed_report_test.php
@@ -81,7 +81,7 @@ class failed_report_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->generatedxapylog, $records);
+        $this->assertCount($this->generatedxapilog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 
@@ -100,7 +100,7 @@ class failed_report_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapilog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 

--- a/tests/failed_report_test.php
+++ b/tests/failed_report_test.php
@@ -81,7 +81,7 @@ class failed_report_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount(1, $records);
+        $this->assertCount($this->generatedxapylog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 
@@ -100,7 +100,7 @@ class failed_report_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 

--- a/tests/history_report_test.php
+++ b/tests/history_report_test.php
@@ -79,7 +79,7 @@ class history_report_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->generatedxapylog, $records);
+        $this->assertCount($this->generatedxapilog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 
@@ -98,7 +98,7 @@ class history_report_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapilog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 

--- a/tests/history_report_test.php
+++ b/tests/history_report_test.php
@@ -79,7 +79,7 @@ class history_report_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount(1, $records);
+        $this->assertCount($this->generatedxapylog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 
@@ -98,7 +98,7 @@ class history_report_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
 
         tool_logstore_xapi_reportfilter_form::mock_submit($this->simulatedsubmitteddata);
 

--- a/tests/moveback_failed_statements_test.php
+++ b/tests/moveback_failed_statements_test.php
@@ -45,7 +45,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->generatedxapylog, $records);
+        $this->assertCount($this->generatedxapilog, $records);
 
         $keys = array_keys($records);
 
@@ -54,7 +54,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         $this->assertTrue($mover->execute());
 
         $expectedcount = new stdClass();
-        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
+        $expectedcount->logstore_xapi_log = $this->generatedxapilog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
     }
@@ -70,7 +70,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapilog, $records);
 
         $keys = array_keys($records);
 
@@ -79,7 +79,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         $this->assertTrue($mover->execute());
 
         $expectedcount = new stdClass();
-        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapylog;
+        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapilog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
     }

--- a/tests/moveback_failed_statements_test.php
+++ b/tests/moveback_failed_statements_test.php
@@ -45,7 +45,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         parent::test_single_element();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount(1, $records);
+        $this->assertCount($this->generatedxapylog, $records);
 
         $keys = array_keys($records);
 
@@ -54,7 +54,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         $this->assertTrue($mover->execute());
 
         $expectedcount = new stdClass();
-        $expectedcount->logstore_xapi_log = 1;
+        $expectedcount->logstore_xapi_log = $this->generatedxapylog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
     }
@@ -70,7 +70,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         parent::test_multiple_elements();
 
         $records = $DB->get_records('logstore_xapi_failed_log');
-        $this->assertCount($this->multipletestnumber, $records);
+        $this->assertCount($this->multipletestnumber * $this->generatedxapylog, $records);
 
         $keys = array_keys($records);
 
@@ -79,7 +79,7 @@ class moveback_failed_statements_test extends enchancement_jisc_skeleton {
         $this->assertTrue($mover->execute());
 
         $expectedcount = new stdClass();
-        $expectedcount->logstore_xapi_log = $this->multipletestnumber;
+        $expectedcount->logstore_xapi_log = $this->multipletestnumber * $this->generatedxapylog;
         $expectedcount->logstore_xapi_failed_log = 0;
         $this->assert_store_tables($expectedcount);
     }


### PR DESCRIPTION
**Description**
Investigate code changes between 3.8 and 3.9
- Update PHP unit tests.
- Solve an issue about coding_exception: Coding error detected, it must be fixed by a programmer: All dataobjects in insert_records() must have the same structure!
- Solve some warnings on comments.

**Related Issues**
LMS-1960

**PR Type**
Fix
