### PR TITLE
Lms 3528 loggedin event failing

### DIFF
--- a/src/transformer/utils/get_verb.php
+++ b/src/transformer/utils/get_verb.php
@@ -46,7 +46,7 @@ function get_verb($verb, array $config, $lang) {
             $output = [
                 'id' => 'https://brindlewaye.com/xAPITerms/verbs/loggedin/',
                 'display' => [
-                    $lang = 'logged into'
+                    $lang => 'logged into'
                 ]
             ];
 

--- a/version.php
+++ b/version.php
@@ -18,7 +18,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin = isset($plugin) && is_object($plugin) ? $plugin : new \stdClass();
 $plugin->component = 'logstore_xapi';
-$plugin->version = 2020062300;
+$plugin->version = 2020100700;
 
 $plugin->release = '';
 $plugin->requires = 2018051700;


### PR DESCRIPTION
**Description**
- The logged_in event was failing with the following output:
```
Type: 400
Event Name: \core\event\user_loggedin
Response:
{
    "errorId": "dd07d942-69c8-4665-961f-f00844a1f66d",
    "warnings": [
        "Expected 'statements.0.verb.display' to be 'Object'. Received '[\"logged into\"]'"
    ]
}
Info: The LDH responded with a 400 error, this can be due to an issue with the recipe.
```

The issue has been resolved by fixing the missing array assignment operator for the `$lang` attribute.

**Related Issues**
- LMS-3528

**PR Type**
- Fix