### PR TITLE
PR-timezonefix: Set the timezone back to site default after the manua…

### DIFF
--- a/src/transformer/utils/create_timestamp.php
+++ b/src/transformer/utils/create_timestamp.php
@@ -17,8 +17,11 @@
 namespace src\transformer\utils;
 defined('MOODLE_INTERNAL') || die();
 
-date_default_timezone_set('Europe/London');
-
 function create_timestamp($time) {
-    return date('c', $time);
+    // Set timezone back to site default after this manual change.
+    $timezone = date_default_timezone_get();
+    date_default_timezone_set('Europe/London');
+    $date = date('c', $time);
+    date_default_timezone_set($timezone);
+    return $date;
 }


### PR DESCRIPTION
…l Europe/London change.

Previously this set the timezone to Europe/London outside of this function, which was causing problems
elsewhere in the system, as once the plugin settings were all loaded by Moodle, the timezone was changing
from the site default. So this change puts it inside the function and then sets it back to the site default
when we are done.

**Description**
- You are setting the timezone to Europe/London which is overriding the site and user defaults set in Moodle. This causes issues in some plugins which are relying on the timezone always being the same. For example:

(If the site default is Europe/Oslo)

On a page which does not call `admin_externalpage_setup()` the timezone is always Europe/Oslo
However on a page which does call `admin_externalpage_setup()` various other calls are made to plugins and the timezone is overwritten as Europe/London.


**PR Type**
- Fix
