### PR TITLE
[Request] Added username and emailAddress to extensions

### DIFF
--- a/src/transformer/utils/extensions/info.php
+++ b/src/transformer/utils/extensions/info.php
@@ -18,12 +18,22 @@ namespace src\transformer\utils\extensions;
 defined('MOODLE_INTERNAL') || die();
 
 function info(array $config, \stdClass $event) {
+    $repo = $config['repo'];
+    $actorId = property_exists($event, 'relateduserid') &&
+                isset($event->relateduserid) ? $event->relateduserid:$event->userid;
+    $user = $repo->read_record_by_id('user', $actorId);
+    $username = property_exists($user, 'username') &&
+                isset($user->username) ? $user->username:"";
+    $emailAddress = property_exists($user, 'email') &&
+                isset($user->email) ? $user->email:"";
     return [
         'http://lrs.learninglocker.net/define/extensions/info' => [
             $config['source_url'] => $config['source_version'],
             $config['plugin_url'] => $config['plugin_version'],
             'event_name' => $event->eventname,
             'event_function' => $config['event_function'],
+            'emailAddress' => $emailAddress,
+            'username' => $username,      
         ],
     ];
 }

--- a/src/transformer/utils/extensions/info.php
+++ b/src/transformer/utils/extensions/info.php
@@ -33,7 +33,7 @@ function info(array $config, \stdClass $event) {
             'event_name' => $event->eventname,
             'event_function' => $config['event_function'],
             'emailAddress' => $emailAddress,
-            'username' => $username,      
+            'username' => $username
         ],
     ];
 }


### PR DESCRIPTION
**Description**
- This PR is in reference to a few requests I noticed under issues that were closed, as well as a similar need for a project I am working on. The need is to be able to include an email address in addition to a username to the actor. Unfortunately since we cannot add to the actor schema, I noticed guidance in the comments that the requester should consider adding additional profile attributes to the extensions schema.  Reference: https://github.com/xAPI-vle/moodle-logstore_xapi/issues/87#issuecomment-257824618. 

- Please comment if there is an alternative option for including both username and email in the actor schema instead, without modifying the plugin to vastly.

**Considerations**
- Leverage Groups in the Actor Schema (Require larger modification of plugin to accomplish than enhancing extensions)
- Add to Extensions schema (Selected)
- Develop new schema (Large level of effort)
- Add to Actor schema (Can't due to restrictions)

**Related Issues**
- #87

**PR Type**
- Enhancement

**Tests**
- Not yet completed, waiting until confirmed solution is logical and sound by maintainers.
- Manually tested and confirmed working in the environment I'm actively supporting.
