### PR TITLE
timezone patch

### DIFF
--- a/src/transformer/utils/create_timestamp.php
+++ b/src/transformer/utils/create_timestamp.php
@@ -27,8 +27,6 @@
 namespace src\transformer\utils;
 defined('MOODLE_INTERNAL') || die();
 
-date_default_timezone_set('Europe/London');
-
 /**
  * Transformer utility to create standard timestamp.
  *
@@ -36,5 +34,10 @@ date_default_timezone_set('Europe/London');
  * @return string
  */
 function create_timestamp($time) {
-    return date('c', $time);
+    // Set timezone back to site default after this manual change.
+    $timezone = date_default_timezone_get();
+    date_default_timezone_set('Europe/London');
+    $date = date('c', $time);
+    date_default_timezone_set($timezone);
+    return $date;
 }


### PR DESCRIPTION
**Description**
- sets back the default_timezone value for other moodle plugins

**PR Type**
- Fix
