### PR TITLE
 #857 - prevent deprecation warnings shown in all admin pages

### DIFF
--- a/src/transformer/get_event_function_map.php
+++ b/src/transformer/get_event_function_map.php
@@ -97,8 +97,14 @@ function get_event_function_map() {
         '\totara_program\event\program_assigned' => 'totara_program\program_assigned'
     ];
 
+    global $CFG;
+    // The use of $CFG->debugusers is interpreted for Moodle core as $forceddebug in the degugging() function.
+    // Disable temporary $CFG->debugusers to prevent debugging messages throughout administration options.
+    $debugusers = $CFG->debugusers;
+    $CFG->debugusers = '';
     $environmentevents = class_exists("report_eventlist_list_generator") ?
         array_keys(\report_eventlist_list_generator::get_all_events_list(false)) : array_keys($availableevents);
+    $CFG->debugusers = $debugusers;
 
     return array_filter($availableevents, function($k) use ($environmentevents) {
         return in_array($k, $environmentevents);


### PR DESCRIPTION
**Description**
- When a Moodle site has $CFG->debugusers, Moodle core considers these users as with forced debugging. As a consequence, having this plugin installed on the Moodle, and having $CFG->debugusers with some users, these users will see deprecation messages from any event on every admin pages (i.e., any page below Administration menu).
- In the same way that Moodle core tries to prevent deprecation messages while calculating the list of events, we propose to backup the value $CFG->debugusers before calculating the list of events, and re-assigning them after this calculation.
- We believe this patch is appropiate for this plugin, since this plugin being installed is what makes the deprecation messages being shown in all and every admin pages for those $CFG->debugusers.

**Related Issues**
- #857 

**PR Type**
- Fix
