### PR TITLE
ISSUE-868: Cannot transform lesson

### DIFF
--- a/src/transformer/utils/get_activity/lesson_question_page.php
+++ b/src/transformer/utils/get_activity/lesson_question_page.php
@@ -53,7 +53,7 @@ function lesson_question_page(array $config, \stdClass $course, \stdClass $lesso
     });
 
     switch ($page->qtype) {
-        case LESSON_PAGE_SHORTANSWER:
+        case 1: // LESSON_PAGE_SHORTANSWER.
             $correctresponses = array_values(
                 array_map(
                     function($answer) {
@@ -70,7 +70,7 @@ function lesson_question_page(array $config, \stdClass $course, \stdClass $lesso
                 $correctresponses
             );
             break;
-        case LESSON_PAGE_ESSAY:
+        case 10: // LESSON_PAGE_ESSAY.
             $activity['definition'] = utils\get_activity\definition\cmi\long_fill_in(
                 $config,
                 $page->title,
@@ -78,8 +78,8 @@ function lesson_question_page(array $config, \stdClass $course, \stdClass $lesso
                 $courselang
             );
             break;
-        case LESSON_PAGE_TRUEFALSE:
-        case LESSON_PAGE_MULTICHOICE:
+        case 2: // LESSON_PAGE_TRUEFALSE.
+        case 3: // LESSON_PAGE_MULTICHOICE.
             $choices = array_values(
                 array_map(
                     function($answer) {
@@ -105,7 +105,7 @@ function lesson_question_page(array $config, \stdClass $course, \stdClass $lesso
                 $correctchoices
             );
             break;
-        case LESSON_PAGE_MATCHING:
+        case 5: // LESSON_PAGE_MATCHING.
             $source = [];
             $target = [];
             foreach ($answers as $a) {
@@ -123,7 +123,7 @@ function lesson_question_page(array $config, \stdClass $course, \stdClass $lesso
                 $courselang
             );
             break;
-        case LESSON_PAGE_NUMERICAL:
+        case 8: // LESSON_PAGE_NUMERICAL.
             // XAPI Numerical can only have one discrete correct response, or a
             // range but lessons do not support ranges, so taking first correct
             // answer to cover most cases.

--- a/src/transformer/utils/get_lesson_question_result.php
+++ b/src/transformer/utils/get_lesson_question_result.php
@@ -46,11 +46,11 @@ function get_lesson_question_result(array $config, \stdClass $lesson, \stdClass 
     ], 'timeseen DESC');
     if (!empty($attempts)) {
         $attempt = reset($attempts);
-        if ($page->qtype == LESSON_PAGE_ESSAY) {
+        if ($page->qtype == 10) { // LESSON_PAGE_ESSAY.
             // Essay is graded later, and is also serialized into an object.
             $essay = unserialize($attempt->useranswer);
             $result['response'] = get_string_html_removed($essay->answer);
-        } else if ($page->qtype == LESSON_PAGE_MATCHING) {
+        } else if ($page->qtype == 5) { // LESSON_PAGE_MATCHING.
             // Matching is the tricky one because the stored response is
             // nothing like the xapi expectation. We need to merge the answers
             // with the responses.


### PR DESCRIPTION
**Description**
- Replaces unloaded constants with their values. In the wild trying to use the constants without loading the related pagetype causes an exception because the code can't find the constant.

**Related Issues**
- #868 

**PR Type**
- Fix 
